### PR TITLE
feat: add session-based admin auth with login form and logout

### DIFF
--- a/application/main.py
+++ b/application/main.py
@@ -225,7 +225,7 @@ else:
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
 # Middleware management
-secret_key=secrets.token_urlsafe(32)
+secret_key = os.getenv("SESSION_SECRET", secrets.token_urlsafe(32))
 app.add_middleware(SetCookieMiddleware)
 app.add_middleware(SessionMiddleware, secret_key=secret_key)
 
@@ -389,13 +389,24 @@ except Exception as e:
     knowledge_base = None
     logging.warning("RAG disabled: %s", e)
 
-# Authentication function
-def authenticate(credentials: HTTPBasicCredentials = Depends(security)):
-    correct_username = "admin"
-    correct_password = "supersecurepassword"
-    if credentials.username != correct_username or credentials.password != correct_password:
-        raise HTTPException(status_code=401, detail="Unauthorized")
-    return credentials.username
+ADMIN_USERNAME = "admin"
+ADMIN_PASSWORD = "supersecurepassword"
+
+# Authentication: accepts session cookie OR HTTP Basic Auth (for API clients)
+def authenticate(request: Request, credentials: HTTPBasicCredentials = Depends(security)):
+    admin = request.session.get("admin")
+    if admin:
+        return admin
+    if credentials.username == ADMIN_USERNAME and credentials.password == ADMIN_PASSWORD:
+        return credentials.username
+    raise HTTPException(status_code=401, detail="Unauthorized")
+
+# Authentication for admin pages: session-only, redirects to login form
+def authenticate_admin_page(request: Request):
+    admin = request.session.get("admin")
+    if admin:
+        return admin
+    raise HTTPException(status_code=307, headers={"Location": "/admin/login"})
 
 # Secure endpoint
 @app.get("/messages")
@@ -433,6 +444,8 @@ def download_messages(
     user: str = Depends(authenticate),
     format: str = "csv",
     chatbot_type: str = None,
+    start_date: str = None,
+    end_date: str = None,
 ):
     """Download all messages as CSV or JSON file."""
     if not POSTGRES_ENABLED:
@@ -446,16 +459,28 @@ def download_messages(
         cursor = conn.cursor(cursor_factory=DictCursor)
 
         query = "SELECT id, session_uuid, msg_id, chatbot_type, user_query, response_content, source, created_at, reaction, user_comment FROM messages"
+        conditions = []
         params = []
         if chatbot_type:
-            query += " WHERE chatbot_type = %s"
+            conditions.append("chatbot_type = %s")
             params.append(chatbot_type)
+        if start_date:
+            conditions.append("created_at >= %s")
+            params.append(start_date)
+        if end_date:
+            conditions.append("created_at <= %s")
+            params.append(end_date + " 23:59:59")
+        if conditions:
+            query += " WHERE " + " AND ".join(conditions)
         query += " ORDER BY created_at DESC"
 
         cursor.execute(query, params)
         rows = cursor.fetchall()
         cursor.close()
         conn.close()
+
+        if not rows:
+            raise HTTPException(status_code=404, detail="No messages found for the selected filters")
 
         today = datetime.date.today().isoformat()
 
@@ -502,8 +527,27 @@ def download_messages(
 
 
 @app.get("/admin/data", response_class=HTMLResponse)
-def admin_data_page(request: Request, user: str = Depends(authenticate)):
+def admin_data_page(request: Request, user: str = Depends(authenticate_admin_page)):
     return templates.TemplateResponse("admin_data.html", {"request": request})
+
+
+@app.get("/admin/login", response_class=HTMLResponse)
+def admin_login_page(request: Request, error: int = 0):
+    return templates.TemplateResponse("admin_login.html", {"request": request, "error": error})
+
+
+@app.post("/admin/login")
+def admin_login(request: Request, username: str = Form(...), password: str = Form(...)):
+    if username == ADMIN_USERNAME and password == ADMIN_PASSWORD:
+        request.session["admin"] = username
+        return RedirectResponse(url="/admin/data", status_code=303)
+    return RedirectResponse(url="/admin/login?error=1", status_code=303)
+
+
+@app.get("/admin/logout")
+def admin_logout(request: Request):
+    request.session.clear()
+    return RedirectResponse(url="/admin/login", status_code=303)
 
 
 def log_message(session_uuid, msg_id, user_query, response_content, source):

--- a/application/sample.env
+++ b/application/sample.env
@@ -32,6 +32,10 @@ AWS_REGION=us-west-2
 # Optional. If omitted, transcript download is disabled.
 # TRANSCRIPT_BUCKET_NAME=
 
+# ── Session / Admin Auth ─────────────────────────────────
+# Optional. If omitted, a random key is generated each restart (sessions won't survive restarts).
+# SESSION_SECRET=
+
 # ── Docker Hub (for docker_build.sh) ─────────────────────
 # Optional. Only needed if pushing to Docker Hub.
 # DOCKER_HUB_USERNAME=

--- a/application/templates/admin_data.html
+++ b/application/templates/admin_data.html
@@ -8,7 +8,12 @@
 </head>
 <body class="bg-light">
   <div class="container py-5" style="max-width: 480px;">
-    <h2 class="mb-4">Download Chat Messages</h2>
+    <div class="d-flex justify-content-between align-items-center mb-4">
+      <h2 class="mb-0">Download Chat Messages</h2>
+      <a href="/admin/logout" class="btn btn-outline-secondary btn-sm">Logout</a>
+    </div>
+
+    <div id="alert-box"></div>
 
     <div class="mb-3">
       <label for="format" class="form-label">Format</label>
@@ -27,18 +32,74 @@
       </select>
     </div>
 
+    <div class="mb-3">
+      <label for="start-date" class="form-label">Start Date</label>
+      <input type="date" id="start-date" class="form-control" />
+    </div>
+
+    <div class="mb-3">
+      <label for="end-date" class="form-label">End Date</label>
+      <input type="date" id="end-date" class="form-control" />
+    </div>
+
     <button id="download-btn" class="btn btn-primary">Download</button>
   </div>
 
   <script>
+    var alertBox = document.getElementById("alert-box");
+
+    function clearAlert() {
+      alertBox.innerHTML = "";
+    }
+
+    document.getElementById("format").addEventListener("change", clearAlert);
+    document.getElementById("chatbot").addEventListener("change", clearAlert);
+    document.getElementById("start-date").addEventListener("change", clearAlert);
+    document.getElementById("end-date").addEventListener("change", clearAlert);
+
     document.getElementById("download-btn").addEventListener("click", function () {
+      clearAlert();
       var fmt = document.getElementById("format").value;
       var chatbot = document.getElementById("chatbot").value;
+      var startDate = document.getElementById("start-date").value;
+      var endDate = document.getElementById("end-date").value;
+
       var url = "/download-messages?format=" + encodeURIComponent(fmt);
       if (chatbot) {
         url += "&chatbot_type=" + encodeURIComponent(chatbot);
       }
-      window.location.href = url;
+      if (startDate) {
+        url += "&start_date=" + encodeURIComponent(startDate);
+      }
+      if (endDate) {
+        url += "&end_date=" + encodeURIComponent(endDate);
+      }
+
+      fetch(url).then(function (response) {
+        if (response.ok) {
+          var filename = "messages." + fmt;
+          var disposition = response.headers.get("Content-Disposition");
+          if (disposition) {
+            var match = disposition.match(/filename="?([^"]+)"?/);
+            if (match) filename = match[1];
+          }
+          return response.blob().then(function (blob) {
+            var a = document.createElement("a");
+            a.href = URL.createObjectURL(blob);
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+          });
+        }
+        return response.json().then(function (data) {
+          var msg = data.detail || "An error occurred";
+          var cls = response.status === 404 ? "alert-warning" : "alert-danger";
+          alertBox.innerHTML = '<div class="alert ' + cls + '">' + msg + '</div>';
+        });
+      }).catch(function () {
+        alertBox.innerHTML = '<div class="alert alert-danger">Network error — please try again</div>';
+      });
     });
   </script>
 </body>

--- a/application/templates/admin_login.html
+++ b/application/templates/admin_login.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Admin Login</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+</head>
+<body class="bg-light">
+  <div class="container py-5" style="max-width: 400px;">
+    <h2 class="mb-4">Admin Login</h2>
+
+    {% if error %}
+    <div class="alert alert-danger">Invalid username or password.</div>
+    {% endif %}
+
+    <form method="post" action="/admin/login">
+      <div class="mb-3">
+        <label for="username" class="form-label">Username</label>
+        <input type="text" id="username" name="username" class="form-control" required autofocus />
+      </div>
+      <div class="mb-3">
+        <label for="password" class="form-label">Password</label>
+        <input type="password" id="password" name="password" class="form-control" required />
+      </div>
+      <button type="submit" class="btn btn-primary w-100">Log in</button>
+    </form>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds session-based authentication for admin pages with a login form and logout functionality
- Protects admin routes (e.g., `/admin/data`) behind authentication

## Test plan
- [ ] Verify admin login form renders at `/admin/data` when not authenticated
- [ ] Verify correct credentials grant access to admin pages
- [ ] Verify logout clears the session and redirects to login
- [ ] Verify unauthenticated requests are blocked from admin endpoints