### PR TITLE
Fix #49: bump LLM max_tokens to 2000 to prevent response truncation

### DIFF
--- a/application/main.py
+++ b/application/main.py
@@ -1194,7 +1194,7 @@ async def chat_api_post(
         chat_history=await memory.get_session_history_all(session_uuid), 
         kb_data=doc_content_str,
         temperature=.5,
-        max_tokens=500,
+        max_tokens=2000,
         endpoint_type="spanish" if response_language == 'es' else "default" )
 
     response_content = await llm_adapter.generate_response(llm_body=llm_body)
@@ -1291,7 +1291,7 @@ async def riverbot_chat_api_post(request: Request, user_query: Annotated[str, Fo
         chat_history=await memory.get_session_history_all(session_uuid), 
         kb_data=doc_content_str,
         temperature=.5,
-        max_tokens=500,
+        max_tokens=2000,
         endpoint_type="riverbot" )
 
     response_content = await llm_adapter.generate_response(llm_body=llm_body)

--- a/application/static/animation/mic.json:Zone.Identifier
+++ b/application/static/animation/mic.json:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://github.com/

--- a/application/static/images/ASU_Sunburst.png:Zone.Identifier
+++ b/application/static/images/ASU_Sunburst.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://github.com/

--- a/application/static/images/Group 11138.svg:Zone.Identifier
+++ b/application/static/images/Group 11138.svg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://www.figma.com/

--- a/application/static/images/background.png:Zone.Identifier
+++ b/application/static/images/background.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://github.com/

--- a/application/static/images/down.png:Zone.Identifier
+++ b/application/static/images/down.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://github.com/

--- a/application/static/images/downIcon.png:Zone.Identifier
+++ b/application/static/images/downIcon.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://github.com/

--- a/application/static/images/icons8-download-64.png:Zone.Identifier
+++ b/application/static/images/icons8-download-64.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://github.com/

--- a/application/static/images/icons8-home-48.png:Zone.Identifier
+++ b/application/static/images/icons8-home-48.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://github.com/

--- a/application/static/images/ion_reload-circle-sharp.svg:Zone.Identifier
+++ b/application/static/images/ion_reload-circle-sharp.svg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://github.com/

--- a/application/static/images/mic_none.png:Zone.Identifier
+++ b/application/static/images/mic_none.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://github.com/

--- a/application/static/images/riverbotBackground.png:Zone.Identifier
+++ b/application/static/images/riverbotBackground.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://www.figma.com/

--- a/application/static/images/riverbotIcon.svg:Zone.Identifier
+++ b/application/static/images/riverbotIcon.svg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://www.figma.com/


### PR DESCRIPTION
## Summary
- Fixes #49: long chatbot responses were truncated mid-word in the admin CSV download at `/admin/data` on https://azwaterbot.org
- Root cause: `max_tokens=500` cap on the LLM call (not the export, not the DB column)
- Two-line config change: `max_tokens=500` → `max_tokens=2000` on both `/chat_api` (main.py:1197) and `/riverbot/chat_api` (main.py:1294)

## Diagnosis details
The truncation pattern (mid-word, e.g. `"...the worlds wo"`) is the textbook signature of `max_tokens` being hit at a token boundary. I empirically verified the export path is fine — `StreamingResponse(StringIO)` does not truncate at any size. The DB column is `response_content TEXT NOT NULL` so no DB-level limit either. Full diagnosis is in [the issue comment](https://github.com/S-Carradini/waterbot/issues/49#issuecomment-4374471887).

## Caveats
- Existing truncated rows in the production DB **cannot be recovered** — only new responses generated after this deploy will be full-length.
- Slightly higher OpenAI cost on long answers (most answers are well under 500 tokens, so overall impact is minor).
- 2000 tokens ≈ 6000–8000 chars in English, comfortably above the longest current responses.

## Test plan
- [x] Backend pytest passes locally (14/14)
- [x] Python syntax check passes
- [ ] Live smoke test on https://azwaterbot.org after AWS ECS redeploys — see [issue comment](https://github.com/S-Carradini/waterbot/issues/49#issuecomment-4374471887) for exact `curl` commands

## Note about commits
This PR contains two commits:
1. `ce3beb0` — incidental cleanup of stale `:Zone.Identifier` Windows browser-metadata files that were already staged in the index from a prior session
2. `ffb752a` — the actual fix for #49

## Note about Railway
This fix only touches the AWS-deployed branches (`main`, `test`). The Railway clone runs from `test-railway-deployment` which has a different file layout (`main.py` at root). That branch has the same `max_tokens=500` bug at lines 1181 and 1277 — needs a separate PR.
