### PR TITLE
Fix #49: bump LLM max_tokens to 2000 (test branch)

### DIFF
--- a/application/main.py
+++ b/application/main.py
@@ -1214,7 +1214,7 @@ async def chat_api_post(
         chat_history=await memory.get_session_history_all(session_uuid), 
         kb_data=doc_content_str,
         temperature=.5,
-        max_tokens=500,
+        max_tokens=2000,
         endpoint_type="spanish" if response_language == 'es' else "default" )
 
     response_content = await llm_adapter.generate_response(llm_body=llm_body)
@@ -1311,7 +1311,7 @@ async def riverbot_chat_api_post(request: Request, user_query: Annotated[str, Fo
         chat_history=await memory.get_session_history_all(session_uuid), 
         kb_data=doc_content_str,
         temperature=.5,
-        max_tokens=500,
+        max_tokens=2000,
         endpoint_type="riverbot" )
 
     response_content = await llm_adapter.generate_response(llm_body=llm_body)


### PR DESCRIPTION
## Summary
Mirror of #54, applied to the `test` branch.

Fixes the same bug (#49): long chatbot responses being cut mid-word due to `max_tokens=500` cap on the LLM call. Two-line change: `max_tokens=500` → `max_tokens=2000` on both `/chat_api` and `/riverbot/chat_api`.

Lines on `test` branch are 1217 and 1314 (differ from `main` due to the CORS middleware addition in this branch).

## Why a separate PR
- `main` and `test` are tracked deployments (AWS prod and AWS test respectively).
- Merging only #54 to main wouldn't fix the test deployment until the next test←main sync.
- Cherry-picking the same trivial change keeps both deployments consistent.

## Test plan
- [x] Diff verified: only the two intended lines change.
- [x] Python syntax check.
- [ ] Verify on https://test.azwaterbot.org after the test deploy completes.
