### PR TITLE
Fix #49: bump LLM max_tokens to 2000 (Railway branch)

### DIFF
--- a/application/main.py
+++ b/application/main.py
@@ -1178,7 +1178,7 @@ async def chat_api_post(
         chat_history=await memory.get_session_history_all(session_uuid), 
         kb_data=doc_content_str,
         temperature=.5,
-        max_tokens=500,
+        max_tokens=2000,
         endpoint_type="spanish" if response_language == 'es' else "default" )
 
     response_content = await llm_adapter.generate_response(llm_body=llm_body)
@@ -1274,7 +1274,7 @@ async def riverbot_chat_api_post(request: Request, user_query: Annotated[str, Fo
         chat_history=await memory.get_session_history_all(session_uuid), 
         kb_data=doc_content_str,
         temperature=.5,
-        max_tokens=500,
+        max_tokens=2000,
         endpoint_type="riverbot" )
 
     response_content = await llm_adapter.generate_response(llm_body=llm_body)


### PR DESCRIPTION
## Summary
Mirror of #54, applied to the `test-railway-deployment` branch (the branch Railway deploys from).

Fixes the same bug (#49): long chatbot responses being cut mid-word due to `max_tokens=500` cap on the LLM call. Two-line change: `max_tokens=500` → `max_tokens=2000` on both `/chat_api` and `/riverbot/chat_api`.

Lines on this branch are 1181 and 1277 (differ from `main`/`test` due to the Railway-only refactor that diverged 9 commits ago).

## Why a separate PR
- This branch is what Railway auto-deploys to https://waterbot-production.up.railway.app
- The `main` ↔ `test-railway-deployment` history diverged 9 commits, so a merge from main would be noisy. Direct fix on this branch keeps the change minimal and reviewable.
- Symptom isn't visible on Railway yet (clone DB has no messages over the 500-token cap), but the underlying bug is identical — fix it now while we have the diagnosis and the fix is fresh.

## Test plan
- [x] Diff verified: only the two intended lines change.
- [x] Python syntax check.
- [ ] After Railway redeploys, send a long-prompt query to https://waterbot-production.up.railway.app/chat_api and confirm the response exceeds 1500 chars and ends with proper punctuation.
