### PR TITLE
Skip chat-formatting Playwright test in CI (no backend)

### DIFF
--- a/frontend/tests/chat-formatting.spec.js
+++ b/frontend/tests/chat-formatting.spec.js
@@ -1,6 +1,10 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Chat response formatting', () => {
+  // CI doesn't run a backend, so /chat_api never responds and the typing indicator never appears.
+  // This is effectively an integration test that needs the FastAPI server + OpenAI key.
+  test.skip(!!process.env.CI, 'Requires running backend; runs locally only');
+
   test('Next Steps response should have compact formatting', async ({ page, browserName }) => {
     test.setTimeout(180000);
 


### PR DESCRIPTION
## Summary
Unblocks the Railway-branch CI deploy by skipping `chat-formatting.spec.js` in CI.

## Root cause
The test sends a real chat message and waits for `.typing-indicator__dot` to appear (max 15s). The dot only appears once `/chat_api` starts streaming a response from OpenAI.

In CI, the workflow only spins up the Vite dev server (`npm run dev`) — there is **no FastAPI backend** running. So `/chat_api` requests hit nothing, the bot never starts typing, the typing indicator never appears, and the test times out.

The other Playwright tests pass because they only check static UI elements (logo presence, message bubble layout, etc.) without depending on a backend response.

## Fix
Mark the entire `Chat response formatting` describe block as `test.skip(!!process.env.CI, ...)`. The test still runs locally where the backend is up.

## Alternatives considered
- **Mock /chat_api with `page.route`**: would let the test run in CI but adds maintenance burden and the test no longer exercises the real formatting pipeline.
- **Start FastAPI in CI**: requires real OPENAI_API_KEY in CI secrets and significant workflow plumbing — disproportionate for one test.

Skipping is the pragmatic call until/unless the test is re-architected for backend-less operation.

## Test plan
- [x] Diff verified: 4 lines added (a comment and the skip statement)
- [ ] Once merged, the Railway deploy workflow's test job will pass and the max_tokens fix from #56 will deploy to https://waterbot-production.up.railway.app
