### PR TITLE
Fix textbox selector (round 2): use .text-input class for InputWrapper

### DIFF
--- a/frontend/tests/user-message-long-text.spec.js
+++ b/frontend/tests/user-message-long-text.spec.js
@@ -7,7 +7,9 @@ test.describe('User Message Long Text', () => {
     await page.goto('/museum/chat');
     await page.waitForLoadState('domcontentloaded');
 
-    const textbox = page.getByRole('textbox', { name: 'Message input' });
+    // The /museum/chat page uses InputWrapper.jsx which has class="text-input"
+    // but no aria-label; placeholder is i18n-dependent. Use the stable CSS class.
+    const textbox = page.locator('.text-input');
     await expect(textbox).toBeVisible();
     await textbox.fill(LONG_MESSAGE);
 


### PR DESCRIPTION
Round-2 selector fix. PR #57 used 'Message input' aria-label which only exists on figma/Composer.jsx; the /museum/chat page actually uses InputWrapper.jsx (no aria-label). Use .text-input class — stable and i18n-independent.