### PR TITLE
Remove Zone.Identifier files from test branch

### DIFF
--- a/application/static/animation/mic.json:Zone.Identifier
+++ b/application/static/animation/mic.json:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://github.com/

--- a/application/static/images/ASU_Sunburst.png:Zone.Identifier
+++ b/application/static/images/ASU_Sunburst.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://github.com/

--- a/application/static/images/Group 11138.svg:Zone.Identifier
+++ b/application/static/images/Group 11138.svg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://www.figma.com/

--- a/application/static/images/background.png:Zone.Identifier
+++ b/application/static/images/background.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://github.com/

--- a/application/static/images/down.png:Zone.Identifier
+++ b/application/static/images/down.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://github.com/

--- a/application/static/images/downIcon.png:Zone.Identifier
+++ b/application/static/images/downIcon.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://github.com/

--- a/application/static/images/icons8-download-64.png:Zone.Identifier
+++ b/application/static/images/icons8-download-64.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://github.com/

--- a/application/static/images/icons8-home-48.png:Zone.Identifier
+++ b/application/static/images/icons8-home-48.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://github.com/

--- a/application/static/images/ion_reload-circle-sharp.svg:Zone.Identifier
+++ b/application/static/images/ion_reload-circle-sharp.svg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://github.com/

--- a/application/static/images/mic_none.png:Zone.Identifier
+++ b/application/static/images/mic_none.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://github.com/

--- a/application/static/images/riverbotBackground.png:Zone.Identifier
+++ b/application/static/images/riverbotBackground.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://www.figma.com/

--- a/application/static/images/riverbotIcon.svg:Zone.Identifier
+++ b/application/static/images/riverbotIcon.svg:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://www.figma.com/


### PR DESCRIPTION
Removes 13 `*:Zone.Identifier` files from `test`. These are Windows NTFS Alternate Data Stream metadata files (created by browsers when downloading) that were accidentally committed. They have `:` in the filename, which Windows reserves and rejects on checkout — causing `git checkout` failures and silent index corruption.

No functional changes. `main` was already cleaned up via PR #54.