### PR TITLE
Keep all 4 follow-up chips on a single row

### DIFF
--- a/frontend/src/styles/figma.css
+++ b/frontend/src/styles/figma.css
@@ -214,11 +214,17 @@
 .reaction-btn:disabled { opacity: 0.5; cursor: default; }
 
 /* ---- Follow-up Chips ---- */
-.follow-up-chips { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 10px; }
+.follow-up-chips {
+  display: flex; flex-wrap: nowrap; gap: 8px; margin-top: 10px;
+  overflow-x: auto; -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+.follow-up-chips::-webkit-scrollbar { display: none; }
 .chip {
   min-height: 40px; padding: 6px 16px; border-radius: var(--wb-radius-pill);
   font-size: 14px; line-height: 20px; border: 1px solid var(--wb-border);
   background: transparent; color: var(--wb-dark); cursor: pointer; transition: all 0.15s;
+  white-space: nowrap; flex-shrink: 0;
 }
 .chip:hover { border-color: var(--wb-accent); background: rgba(127,180,203,0.1); }
 .chip:disabled { opacity: 0.5; cursor: default; }


### PR DESCRIPTION
Follow-up to #62. The new ''Give an Example'' chip wrapped to a new line because the container used `flex-wrap: wrap` with 4 chips no longer fitting at typical container widths. Switching to `nowrap` with `overflow-x: auto` keeps all chips on one row and lets them scroll horizontally on narrow screens.