### PR TITLE
Shrink chip padding/gap so all 4 chips fit without clipping

### DIFF
--- a/frontend/src/styles/figma.css
+++ b/frontend/src/styles/figma.css
@@ -215,14 +215,14 @@
 
 /* ---- Follow-up Chips ---- */
 .follow-up-chips {
-  display: flex; flex-wrap: nowrap; gap: 8px; margin-top: 10px;
+  display: flex; flex-wrap: nowrap; gap: 6px; margin-top: 10px;
   overflow-x: auto; -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
 }
 .follow-up-chips::-webkit-scrollbar { display: none; }
 .chip {
-  min-height: 40px; padding: 6px 16px; border-radius: var(--wb-radius-pill);
-  font-size: 14px; line-height: 20px; border: 1px solid var(--wb-border);
+  min-height: 36px; padding: 6px 10px; border-radius: var(--wb-radius-pill);
+  font-size: 13px; line-height: 18px; border: 1px solid var(--wb-border);
   background: transparent; color: var(--wb-dark); cursor: pointer; transition: all 0.15s;
   white-space: nowrap; flex-shrink: 0;
 }


### PR DESCRIPTION
Follow-up to #62/#63. The 4th chip (Give an Example) was being clipped by ~25% on the right because the bot bubble caps at 65% width on desktop, leaving ~430px for chips that needed ~480px. Reducing chip padding (16px → 10px), font (14px → 13px), and gap (8px → 6px) brings the row to ~386px — all 4 fit comfortably with slack for Spanish label widths.